### PR TITLE
docs(profile): update README with enhanced descriptions

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,11 +6,13 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10432/badge)](https://www.bestpractices.dev/projects/10432)
 [![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fdragonfly_oss)](https://twitter.com/dragonfly_oss)
 [![LICENSE](https://img.shields.io/github/license/dragonflyoss/dragonfly.svg?style=flat-square)](https://github.com/dragonflyoss/dragonfly/blob/main/LICENSE)
+[![LFX Health Score](https://img.shields.io/static/v1?label=Health%20Score&message=Healthy&color=A7F3D0&logo=linuxfoundation&logoColor=white&style=flat)](https://insights.linuxfoundation.org/project/d7y)
+[![CNCF Status](https://img.shields.io/badge/CNCF%20Status-Graduated-informational)](https://www.cncf.io/projects/dragonfly/)
 
-Delivers efficient, stable, and secure data distribution and acceleration powered by P2P technology.
-It aims to be the best practice and standard solution in cloud native architectures.
-Designed to improve the performance of large‑scale delivery across files, container images,
-OCI artifacts, AI models, caches, logs, dependencies, etc.
+Delivers efficient, stable, and secure data distribution and acceleration powered by P2P technology,
+with an optional content‑addressable filesystem that accelerates OCI container launch. It aims to provide a best‑practice,
+standards‑based solution for cloud‑native architectures, improving large‑scale delivery of files, container images,
+OCI artifacts, AI/ML models, caches, logs, dependencies, etc.
 
 ### Documentation
 
@@ -21,7 +23,7 @@ You can find the full documentation on the [d7y.io](https://d7y.io).
 Join the conversation and help the community grow. Here are the ways to get involved:
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Github Discussions**: [Dragonfly Discussion Forum][discussion]
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
 - **Mailing Lists**:
   - **Developers**: <dragonfly-developers@googlegroups.com>


### PR DESCRIPTION
This pull request updates the `profile/README.md` file to improve the project description and update the community links for better clarity and accuracy.

Project description improvements:

* Enhanced the main description to mention the optional content-addressable filesystem for accelerating OCI container launches, clarified its standards-based approach, and expanded the list of supported artifact types.

Community and documentation links:

* Updated the "Github Discussions" link to point directly to the Dragonfly Discussion Forum on GitHub, replacing the previous reference format.

Issue: https://github.com/dragonflyoss/dragonfly/issues/4425